### PR TITLE
Amazon CloudFront content negotiation (gzip compression) compatibility

### DIFF
--- a/lib/droid.py
+++ b/lib/droid.py
@@ -83,7 +83,7 @@ class ResourceExpertDroid(RedFetcher):
         self.ims_support = None
         self.gzip_support = None
         self.gzip_savings = 0
-        rh = self.orig_req_hdrs + [('Accept-Encoding', 'gzip')]
+        rh = self.orig_req_hdrs + [('Accept-Encoding', 'gzip, deflate')]
         RedFetcher.__init__(self, uri, method, rh, req_body,
                             status_cb, body_procs, req_type=method)
 


### PR DESCRIPTION
This is really all it takes for REDbot to become compatible with Amazon CloudFront. Although it really is Amazon CloudFront who's at fault here…
