### PR TITLE
Addition of a reference about the Apache's ETag bug

### DIFF
--- a/redbot/speak.py
+++ b/redbot/speak.py
@@ -1144,8 +1144,8 @@ class VARY_ETAG_DOESNT_CHANGE(Note):
     This resource, however, sent the same strong ETag for both its compressed
     and uncompressed versions (negotiated by <code>Accept-Encoding</code>).
     This can cause interoperability problems, especially with caches.<p>
-    Please note that the Apache HTTP Server doesn't follow specifications and always sends
-    the same ETag for both compressed and uncompressed versions of a ressource.
+    Please note that some versions of the Apache HTTP Server sometimes send
+    the same ETag for both compressed and uncompressed versions of a ressource. 
     This is a <a href="https://issues.apache.org/bugzilla/show_bug.cgi?id=39727">known bug</a>."""
     }
 


### PR DESCRIPTION
Addition of a reference about the [Apache's ETag bug](https://issues.apache.org/bugzilla/show_bug.cgi?id=46538) in the corresponding error text according to a [suggestion of Stéphane Bortzmeyer](https://github.com/mnot/redbot/issues/135).
