### PR TITLE
Update X-Frame-Options support

### DIFF
--- a/redbot/speak.py
+++ b/redbot/speak.py
@@ -634,7 +634,6 @@ will be contained within a frame."
      IE8 handles HTML frames; the <code>DENY</code> value prevents this
      content from being rendered within a frame, which defends against certain
      types of attacks.<p>
-     Currently this is supported by IE8 and Safari 4.<p>
      See <a href="http://bit.ly/v5Bh5Q">this blog entry</a> for more
      information.
      """


### PR DESCRIPTION
The `X-Frame-Options` help text says that it's only supported in IE 8 and Safari.  This is [decidedly outdated information](https://en.wikipedia.org/wiki/Clickjacking#Server_and_client), as Chrome, Firefox and Opera have supported it [for years](https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options#Browser_compatibility):

![image](https://cloud.githubusercontent.com/assets/23369/3714768/bb49939c-15bb-11e4-9114-ef7e05d3666c.png)

Rather than note that all major browsers support it, I figured we should just remove any note at all, and let that be implied.
