### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,17 +9,18 @@ MAINTAINER Julien Rottenberg <julien@rottenberg.info>
 
 ENV        DEBIAN_FRONTEND noninteractive
 ENV        PYTHONPATH      /redbot
+ENV        PATH            $PATH:/redbot/bin
 
 
 # Install python requirements
-RUN        apt-get install -y python-setuptools && easy_install thor
+RUN        apt-get install -y python-setuptools python-openssl && easy_install thor
 
 
-ADD        . /redbot
+ADD        .  /redbot
 
 
 # Expose ports.
 EXPOSE     80
 
 # Define default command.
-ENTRYPOINT /redbot/bin/webui.py 80 /redbot/share
+CMD        webui.py 80 /redbot/share

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,19 +8,19 @@ FROM ubuntu:14.10
 MAINTAINER Julien Rottenberg <julien@rottenberg.info>
 
 ENV        DEBIAN_FRONTEND noninteractive
-ENV        PYTHONPATH      /redbot
-ENV        PATH            $PATH:/redbot/bin
+ENV        PYTHONPATH=/redbot
 
 
 # Install python requirements
-RUN        apt-get install -y python-setuptools python-openssl && easy_install thor
+RUN        apt-get update && apt-get install -y python-setuptools make phantomjs && easy_install thor selenium
 
+ADD        . /redbot
 
-ADD        .  /redbot
+RUN        make --directory=/redbot/test
 
 
 # Expose ports.
 EXPOSE     80
 
 # Define default command.
-CMD        webui.py 80 /redbot/share
+ENTRYPOINT /redbot/bin/webui.py 80 /redbot/share

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# redbot
+#
+# https://github.com/mnot/redbot
+
+# Pull base image.
+FROM ubuntu:14.10
+
+MAINTAINER Julien Rottenberg <julien@rottenberg.info>
+
+ENV        DEBIAN_FRONTEND noninteractive
+ENV        PYTHONPATH      /redbot
+
+
+# Install python requirements
+RUN        apt-get install -y python-setuptools && easy_install thor
+
+
+ADD        . /redbot
+
+
+# Expose ports.
+EXPOSE     80
+
+# Define default command.
+ENTRYPOINT /redbot/bin/webui.py 80 /redbot/share

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM ubuntu:14.10
 MAINTAINER Julien Rottenberg <julien@rottenberg.info>
 
 ENV        DEBIAN_FRONTEND noninteractive
-ENV        PYTHONPATH=/redbot
+ENV        PYTHONPATH      /redbot
 
 
 # Install python requirements

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Start the webserver
 
 Use the command line
 
-  docker run redbot redbot <url>
+  docker run --entrypoint=/redbot/bin/redbot redbot <url>
 
 
 

--- a/README.rst
+++ b/README.rst
@@ -32,11 +32,11 @@ Unpack the RED tarball. There are a number of interesting files:
 - redbot/ - RED's Python library files
 - share/ - RED's CSS stylesheet and JavaScript libraries
 
-To install from source (e.g., if you clone from github):: 
+To install from source (e.g., if you clone from github)::
 
   python setup.py install
-  
-installs RED's libraries as well as the command-line version as 'redbot'. 
+
+installs RED's libraries as well as the command-line version as 'redbot'.
 
 Setting up your Web Server
 --------------------------
@@ -47,8 +47,8 @@ these configuration directives (e.g., in .htaccess, if enabled)::
 
   AddHandler cgi-script .py
   DirectoryIndex webui.py
-  
-If the directory is the root directory for your server "example.com", 
+
+If the directory is the root directory for your server "example.com",
 this will configure RED to be at the URI "http://example.com/".
 
 The contents of the share directory* also need to be made available on the
@@ -63,7 +63,7 @@ configure a cron job to regularly clean it. For example::
 
   0 * * * * find /var/state/redbot/ -mmin +360 -exec rm {} \;
 
-If you don't want to allow users to store responses, set save_dir to 'None'.  
+If you don't want to allow users to store responses, set save_dir to 'None'.
 
 * Note that you really only need script.js and style.js, but it doesn't hurt to have the rest.
 
@@ -75,9 +75,25 @@ It's also possible to run RED as a mod_python handler. For example::
   AddHandler mod_python .py
   PythonHandler webui::mod_python_handler
 
-If you use mod_python, make sure your server has enough memory for the 
+If you use mod_python, make sure your server has enough memory for the
 number of Apache children you configure; each child should use anywhere from
 20M-35M of RAM.
+
+Docker deployment
+-----------------
+
+You can also build the project through docker, clone from github then :
+
+  docker build -t redbot .
+
+Start the webserver
+
+   docker run -p 8080:80 redbot
+
+Use the command line
+
+  docker run --entrypoint=/redbot/bin/redbot redbot <url>
+
 
 
 Support, Reporting Issues and Contributing
@@ -91,7 +107,7 @@ Credits
 -------
 
 Icons by Momenticon <http://momenticon.com/>. REDbot also includes code
-from jQuery <http://jquery.com/> and prettify.js 
+from jQuery <http://jquery.com/> and prettify.js
 <http://code.google.com/p/google-code-prettify/>.
 
 License

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Start the webserver
 
 Use the command line
 
-  docker run --entrypoint=/redbot/bin/redbot redbot <url>
+  docker run redbot redbot <url>
 
 
 


### PR DESCRIPTION
Enable a docker based build.

Allow image to be run standalone or through the command line.

Also, test it with :

      docker run -p 8080:80 jrottenberg/redbot

or

    docker run  --entrypoint=/redbot/bin/redbot jrottenberg/redbot http://www.github.com/
