### PR TITLE
Added HTTP Error Code 418 I'm a Teapot

### DIFF
--- a/bin/webui.py
+++ b/bin/webui.py
@@ -114,6 +114,7 @@ def mod_python_handler(r):
         415: apache.HTTP_UNSUPPORTED_MEDIA_TYPE,
         416: apache.HTTP_RANGE_NOT_SATISFIABLE,
         417: apache.HTTP_EXPECTATION_FAILED,
+        418: apache.HTTP_IM_A_TEAPOT,
         422: apache.HTTP_UNPROCESSABLE_ENTITY,
         423: apache.HTTP_LOCKED,
         424: apache.HTTP_FAILED_DEPENDENCY,

--- a/bin/webui.py
+++ b/bin/webui.py
@@ -114,7 +114,6 @@ def mod_python_handler(r):
         415: apache.HTTP_UNSUPPORTED_MEDIA_TYPE,
         416: apache.HTTP_RANGE_NOT_SATISFIABLE,
         417: apache.HTTP_EXPECTATION_FAILED,
-        418: apache.HTTP_IM_A_TEAPOT,
         422: apache.HTTP_UNPROCESSABLE_ENTITY,
         423: apache.HTTP_LOCKED,
         424: apache.HTTP_FAILED_DEPENDENCY,
@@ -149,11 +148,11 @@ def cgi_main():
     """Run REDbot as a CGI Script."""
     def out(inbytes):
         try:
-            sys.stdout.buffer.write(inbytes)             
+            sys.stdout.buffer.write(inbytes)
             sys.stdout.flush()
-        except IOError: 
+        except IOError:
             pass
-            
+
     ui_uri = "%s://%s%s%s" % (
         'HTTPS' in os.environ and "https" or "http",
         os.environ.get('HTTP_HOST'),

--- a/redbot/message/status.py
+++ b/redbot/message/status.py
@@ -129,6 +129,8 @@ class StatusChecker(object):
         pass # TODO: test to see if it's true, alter if not
     def status417(self) -> None:        # Expectation Failed
         pass # TODO: explain, alert if it's 100-continue
+    def status418(self) -> None:
+        self.add_note('', STATUS_IM_A_TEAPOT)
     def status422(self) -> None:        # Unprocessable Entity
         pass
     def status423(self) -> None:        # Locked
@@ -339,6 +341,13 @@ class STATUS_UNSUPPORTED_MEDIA_TYPE(Note):
     summary = "The resource doesn't support this media type in requests."
     text = """\
  """
+
+class STATUS_IM_A_TEAPOT(Note):
+    category = categories.GENERAL
+    level = levels.INFO
+    summary = "Teapot is requested to brew coffee."
+    text = """\
+    """
 
 class STATUS_INTERNAL_SERVICE_ERROR(Note):
     category = categories.GENERAL

--- a/redbot/message/status.py
+++ b/redbot/message/status.py
@@ -344,10 +344,16 @@ class STATUS_UNSUPPORTED_MEDIA_TYPE(Note):
 
 class STATUS_IM_A_TEAPOT(Note):
     category = categories.GENERAL
-    level = levels.INFO
-    summary = "Teapot is requested to brew coffee."
+    level = levels.WARN
+    summary = "The server returned 418 I'm a Teapot, an easter egg defined in RFC 2324."
     text = """\
-    """
+RFC 2324 was an April 1 RFC that lampooned the various ways HTTP was abused; one such abuse
+was the definition of the application-specific 418 (I'm a Teapot) status code. In the
+intervening years, this status code has been widely implemented as an "easter egg".
+
+This status code is not a part of HTTP and hence it might not be supported by some strict
+standards-compliant clients.
+"""
 
 class STATUS_INTERNAL_SERVICE_ERROR(Note):
     category = categories.GENERAL


### PR DESCRIPTION
redbot fails to implement the 418 I'm a Teapot status code.

Its source is [RFC2324, Hyper Text Coffee Pot Control Protocol (HTCPCP/1.0)](https://www.ietf.org/rfc/rfc2324.txt).

Please consider adding support for 418 from Node, since [The Internet Engineering Task Force is officially working on reserving 418](https://tools.ietf.org/html/draft-nottingham-thanks-larry-00).

Thanks,

/cc @mnot 

(Relevant [PR](https://github.com/grisha/mod_python/pull/64) for mod_python.)