### PR TITLE
Update command executed in Dockerfile to install using requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3-alpine
 WORKDIR /redbot
 COPY . /redbot
 
-RUN pip install --trusted-host -r requirements.txt
+RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
 EXPOSE 8000
 


### PR DESCRIPTION
Closes #267 

With this change, running `docker build -t redbot .` worked with no issues. Then running `docker run -p 8000:8000 --rm --name redbot redbot` started the server at `http://localhost:8000`. 