### PR TITLE
Include more packages to alpine to fix gcc and cffi build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3-alpine
 WORKDIR /redbot
 COPY . /redbot
 
+RUN apk add --no-cache libffi-dev build-base openssl-dev
+
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
 EXPOSE 8000


### PR DESCRIPTION
Hi

The `requirements.txt` file changed, and due to missing packages in alpine `pip` failed to install it.

Never used CircleCI, but if it supports Travis like Travis &GH actions, `make docker` could be part of the CI builds to catch issues like this I think.

Thanks!
Bruno