### PR TITLE
Name container redbot to avoid creating multiple instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ docker-image:
 
 .PHONY: docker
 docker: docker-image
-	docker run -p 8000:8000 redbot
+	docker run --rm --name redbot -p 8000:8000 redbot
 
 #############################################################################
 ## Distribution


### PR DESCRIPTION
Was cleaning up my containers and noticed several with randomly generated names for redbot (from my tests this afternoon). This PR sets the container to be removed once stopped, and to have a name `redbot`.

The container doesn't seem to persist any data, but in case if does we can still use a volume later.