### PR TITLE
Use config file for redbot_cli

### DIFF
--- a/bin/redbot_cli
+++ b/bin/redbot_cli
@@ -9,6 +9,7 @@ __author__ = "Jerome Renard <jerome.renard@gmail.com>"
 from configparser import ConfigParser
 from argparse import ArgumentParser
 import sys
+import os
 
 import thor
 
@@ -45,7 +46,7 @@ def main() -> None:
     args = parser.parse_args()
 
     config_parser = ConfigParser()
-    config_parser.read_dict({"redbot": {"lang": "en", "charset": "utf-8"}})
+    config_parser.read(os.environ.get("REDBOT_CONFIG", "config.txt"))
     config = config_parser["redbot"]
 
     resource = HttpResource(config, descend=args.descend)


### PR DESCRIPTION
Currently, `redbot_cli` uses a fixed config that is not easy to change.
The changes make `redbot_cli` use the same config file as the other services.