### PR TITLE
Fix typo in validator link

### DIFF
--- a/redbot/formatter/html.py
+++ b/redbot/formatter/html.py
@@ -72,7 +72,7 @@ class SingleEntryHtmlFormatter(BaseHtmlFormatter):
         "text/css": "https://jigsaw.w3.org/css-validator/validator?uri=%s&",
         "application/xhtml+xml": "https://validator.w3.org/check?uri=%s",
         "application/atom+xml": "https://validator.w3.org/feed/check.cgi?url=%s",
-        "application/rss+xml": "https://validator.w3.org/feed/check.cgi?url==%s",
+        "application/rss+xml": "https://validator.w3.org/feed/check.cgi?url=%s",
     }
 
     name = "html"


### PR DESCRIPTION
Extra `=` in one of the validator links.