### PR TITLE
Docker: python:3-slim-bookworm, Docker Image CI: produce pre-builded docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Ignore git and .git folder
+.git
+.gitignore
+.github
+
+# Ignore cache and temporary files
+*.pyc
+*.pyo
+*.egg-info
+dist/
+build/
+
+# Ignore logs
+*.log
+
+# Ignore IDE and editor folders/files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Ignore other non-relevant files
+README.md
+Dockerfile
+LICENSE
+
+# From .gitingore 
+*.pyc
+__pycache__
+.DS_Store
+/MANIFEST
+/dist
+/build
+ghostdriver.log
+geckodriver.log
+/.sass-cache
+/.coverage
+/.mypy_cache
+/.pytest_cache
+/.venv
+/redbot.egg-info
+/.npx-cache
+/src/node_modules
+/throwaway

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,60 @@
+name: Docker Image CI
+
+on:
+  workflow_dispatch: # Allow manual triggers from the Actions tab.    
+  push:
+    tags: [ 'v*.*.*' ] # Publish semver tags as releases.
+
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write      
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log into registry ${{ env.REGISTRY }}'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Metadata action
+        uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign the published Docker image
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Sign the published Docker image
         env:
           COSIGN_EXPERIMENTAL: "true"
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign --tlog-upload=false {}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3-slim-bookworm
 
+# Notes:
+# Locales are needed for the redbot_daemon.py to run
+# locale.normalize(conf["redbot"]["lang"]) = "en_US.ISO8859-1"
+# by default we will install all standard en_US locales (en_US.ISO-8859-1, en_US.ISO-8859-15, en_US.UTF-8)
+
 # Install necessary Debian packages
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -7,7 +12,7 @@ RUN apt-get update && \
     build-essential \
     openssl \
     locales \
-    && sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \ 
+    && sed -i '/^# *en_US/s/^# *//' /etc/locale.gen \
     && locale-gen \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,25 @@
-FROM python:3-alpine
+FROM python:3-slim-bookworm
+
+# Install necessary Debian packages
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libffi-dev \
+    build-essential \
+    openssl \
+    locales \
+    && sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen \ 
+    && locale-gen \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /redbot
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir --trusted-host pypi.python.org -r requirements.txt
 COPY . /redbot
-
-RUN apk add --no-cache libffi-dev build-base openssl-dev
-
-RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
 EXPOSE 8000
 
 ENV PYTHONPATH /redbot
 ENV PYTHONUNBUFFERED true
-ENTRYPOINT ["python", "bin/redbot_daemon.py", "extra/config-docker.txt"]
+ENTRYPOINT ["python"] 
+CMD ["bin/redbot_daemon.py", "extra/config-docker.txt"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ EXPOSE 8000
 ENV PYTHONPATH /redbot
 ENV PYTHONUNBUFFERED true
 ENTRYPOINT ["python"] 
-CMD ["bin/redbot_daemon.py", "extra/config-docker.txt"]
+CMD ["redbot/daemon.py", "extra/config-docker.txt"]

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ docker-image:
 docker: docker-image
 	docker run --rm --name redbot -p 8000:8000 redbot
 
+.PHONY: docker-cli
+docker-cli: docker-image
+	docker run --rm --name redbot redbot redbot/cli.py https://redbot.org/
+
 #############################################################################
 ## Distribution
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Or, just:
 
 to run REDbot on port 8000.
 
+Run REDbot in cli mode:
+
+> docker run --rm redbot redbot/cli.py https://redbot.org/
 
 
 ## Credits

--- a/redbot/daemon.py
+++ b/redbot/daemon.py
@@ -241,8 +241,9 @@ def main() -> None:
 
     try:
         locale.setlocale(locale.LC_ALL, locale.normalize(conf["redbot"]["lang"]))
-    except ValueError:
-        locale.setlocale(locale.LC_ALL, "")
+    except locale.Error: # Catch more general locale-related error
+        print("Warning: Failed to set locale from config. Using default 'en' locale.")
+        locale.setlocale(locale.LC_ALL, 'en_US.UTF-8') # Default to English locale
 
     sys.stderr.write(
         f"Starting on PID {os.getpid()}... (thor {thor.__version__})\n"


### PR DESCRIPTION
I did't use pipx or python -m build (make build) right now, but it is possible to implement 
This PR is just for get docker images for each tag
Could be used as a good start 

Related PRs: #308

P.S. python -m build give me version 1.5 all the time. So, we could make more changes after the next release.


In case of someone looking for pre-builded images: https://github.com/cageyv/redbot/pkgs/container/redbot
