### PR TITLE
Fix typos

### DIFF
--- a/Makefile.venv
+++ b/Makefile.venv
@@ -42,7 +42,7 @@
 #
 # This Makefile can be configured via following variables:
 #   PY
-#       Command name for system Python interpreter. It is used only initialy to
+#       Command name for system Python interpreter. It is used only initially to
 #       create the virtual environment
 #       Default: python3
 #   REQUIREMENTS_TXT

--- a/redbot/message/cache.py
+++ b/redbot/message/cache.py
@@ -53,7 +53,7 @@ def check_caching(response: HttpResponse, request: HttpRequest = None) -> None:
         "stale-if-error",
     ]
 
-    # check for mis-capitalised directives /
+    # check for miscapitalised directives /
     # assure there aren't any dup directives with different values
     for cc in cc_keys:
         if cc.lower() in known_cc and cc != cc.lower():
@@ -86,7 +86,7 @@ def check_caching(response: HttpResponse, request: HttpRequest = None) -> None:
         response.add_note("header-cache-control", PRIVATE_AUTH)
     else:
         response.store_shared = response.store_private = True
-        response.add_note("header-cache-control", STOREABLE)
+        response.add_note("header-cache-control", STORABLE)
 
     # no-cache?
     if "no-cache" in cc_keys:
@@ -328,7 +328,7 @@ directive, this response can only be stored by caches that are specific to a sin
 example, a browser cache. Shared caches, such as those in proxies, cannot store it."""
 
 
-class STOREABLE(Note):
+class STORABLE(Note):
     category = categories.CACHING
     level = levels.INFO
     summary = """\
@@ -500,7 +500,7 @@ class FRESHNESS_NONE(Note):
 directive, or `Expires` header), and this status code doesn't allow caches to calculate their own.
 
 Therefore, while caches may be allowed to store it, they can't use it, except in unusual
-cirucumstances, such a when the origin server can't be contacted.
+circumstances, such a when the origin server can't be contacted.
 
 This behaviour can be prevented by using the `Cache-Control: must-revalidate` response directive.
 
@@ -728,7 +728,7 @@ class DATE_CLOCKLESS(Note):
     level = levels.WARN
     summary = "%(response)s doesn't have a Date header."
     text = """\
-Although HTTP allowes a server not to send a `Date` header if it doesn't have a local clock, this
+Although HTTP allows a server not to send a `Date` header if it doesn't have a local clock, this
 can make calculation of the response's age inexact."""
 
 

--- a/redbot/message/headers/README.md
+++ b/redbot/message/headers/README.md
@@ -116,7 +116,7 @@ variable.
 
 ## Notes
 
-Header definitions should also include header specific _Note_ classses. 
+Header definitions should also include header specific _Note_ classes.
 
 When writing new notes, it's important to keep in mind that the `text` field is expected to contain
 valid HTML; any variables you pass to it will be escaped for you before rendering.
@@ -128,12 +128,12 @@ Each header definition should also include tests, as subclasses of
 `redbot.message.headers.HeaderTest`. It expects the following class properties:
 
  * `name` - the header field-name
- * `inputs` - a list of header field-values, one item per line. 
+ * `inputs` - a list of header field-values, one item per line.
    E.g., `["foo", "foo, bar"]`
  * `expected_out` - the data structure that _parse_ should return, given
    the inputs
  * `expected_err` - a list of `redbot.speak.Note` classes that are expected
    to be set with `add_note` when parsing the inputs
-    
+
 You can create any number of tests this way; they will be run automatically when
 _tests/test\_headers.py_ is run.

--- a/redbot/message/headers/_notes.py
+++ b/redbot/message/headers/_notes.py
@@ -187,7 +187,7 @@ class RESPONSE_HDR_IN_REQUEST(Note):
     level = levels.BAD
     summary = '"%(field_name)s" is a request header.'
     text = """\
-%(field_name)s isn't defined to have any meaning in reqeusts, so REDbot has ignored it."""
+%(field_name)s isn't defined to have any meaning in requests, so REDbot has ignored it."""
 
 
 class HEADER_DEPRECATED(Note):

--- a/redbot/message/headers/transfer_encoding.py
+++ b/redbot/message/headers/transfer_encoding.py
@@ -48,7 +48,7 @@ class TRANSFER_CODING_IDENTITY(Note):
     summary = "The identity transfer-coding isn't necessary."
     text = """\
 HTTP defines _transfer-codings_ as a hop-by-hop encoding of the message content. The `identity`
-tranfer-coding was defined as the absence of encoding; it doesn't do anything, so it's necessary.
+transfer-coding was defined as the absence of encoding; it doesn't do anything, so it's necessary.
 
 You can remove this token to save a few bytes."""
 

--- a/redbot/message/headers/x_content_type_options.py
+++ b/redbot/message/headers/x_content_type_options.py
@@ -22,7 +22,7 @@ class CONTENT_TYPE_OPTIONS(Note):
     level = levels.INFO
     summary = "%(response)s instructs browsers not to 'sniff' its media type."
     text = """\
-Many Web browers "sniff" the media type of responses to figure out whether they're HTML, RSS or
+Many Web browsers "sniff" the media type of responses to figure out whether they're HTML, RSS or
 another format, no matter what the `Content-Type` header says.
 
 This header instructs browsers not to do this, but to always respect the

--- a/redbot/message/headers/x_ua_compatible.py
+++ b/redbot/message/headers/x_ua_compatible.py
@@ -55,7 +55,7 @@ class UA_COMPATIBLE_REPEAT(Note):
     text = """\
 Internet Explorer 8 allows responses to explicitly set the rendering mode used for a page.
 
-This response has more than one such directive targetted at one browser; this may cause
+This response has more than one such directive targeted at one browser; this may cause
 unpredictable results.
 
 See [this blog entry](http://msdn.microsoft.com/en-us/library/cc288325(VS.85).aspx) for more

--- a/redbot/webui/__init__.py
+++ b/redbot/webui/__init__.py
@@ -344,7 +344,7 @@ class RedWebUi:
 
     def get_client_id(self) -> str:
         """
-        Figure out an identifer for the client.
+        Figure out an identifier for the client.
         """
         xff = thor.http.common.get_header(self.req_headers, b"x-forwarded-for")
         if xff:


### PR DESCRIPTION
Found few misspellings with `typos`.

@mnot The only code change is `STOREABLE -> STORABLE`