### PR TITLE
Changed: bump httplint and thor; adapt to new APIs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,13 @@ classifiers = [
 ]
 license-files = ["LICENSE.md"]
 dependencies = [
-    "httplint >= 2026.04.03",
+    "httplint >= 2026.05.01",
     "importlib_resources",
     "Jinja2 >= 3.1.2",
     "markdown >= 3.4.4",
     "MarkupSafe >= 2.1.3",
     "netaddr >= 1.2.1",
-    "thor >= 0.13.0",
+    "thor >= 0.14.0",
     "typing-extensions >= 4.8.0",
 ]
 

--- a/redbot/formatter/text.py
+++ b/redbot/formatter/text.py
@@ -63,16 +63,26 @@ class BaseTextFormatter(Formatter):
             if self.resource.response.complete:
                 self.output(self.format_headers(self.resource.response) + NL + NL)
             elif isinstance(self.resource.fetch_error, httperr.HttpError):
-                self.output(self.error_template % self.resource.fetch_error.desc)
+                self.output(
+                    self.error_template % self._format_fetch_error(self.resource.fetch_error)
+                )
 
             self.output(self.format_recommendations(self.resource) + NL)
         else:
             if self.resource.fetch_error is None:
                 pass
             elif isinstance(self.resource.fetch_error, httperr.HttpError):
-                self.output(self.error_template % self.resource.fetch_error.desc)
+                self.output(
+                    self.error_template % self._format_fetch_error(self.resource.fetch_error)
+                )
             else:
                 raise AssertionError("Unknown incomplete response error.")
+
+    @staticmethod
+    def _format_fetch_error(error: httperr.HttpError) -> str:
+        if error.detail:
+            return f"{error.desc} ({error.detail})"
+        return error.desc
 
     def error_output(self, message: str) -> None:
         self.output(self.error_template % message)

--- a/redbot/note.py
+++ b/redbot/note.py
@@ -1,7 +1,23 @@
+from threading import local
+
 from httplint.note import Note
+from markdown import Markdown
 from markupsafe import Markup, escape
 
 from redbot.i18n import _, get_locale
+
+
+class _MdLocal(local):
+    md: Markdown
+
+
+_md_local = _MdLocal()
+
+
+def _markdown() -> Markdown:
+    if not hasattr(_md_local, "md"):
+        _md_local.md = Markdown(output_format="html")
+    return _md_local.md
 
 
 class RedbotNote(Note):
@@ -9,9 +25,9 @@ class RedbotNote(Note):
     A Note that uses REDbot's translation domain.
     """
 
-    def _get_summary(self) -> Markup:
+    def _get_summary(self) -> str:
         try:
-            return Markup(_(self._summary) % self.vars)
+            return str(_(self._summary) % self.vars)
         except TypeError as err:
             raise TypeError(
                 f"Summary formatting error in {self.__class__.__name__} "
@@ -21,9 +37,9 @@ class RedbotNote(Note):
     def _get_detail(self) -> Markup:
         try:
             return Markup(
-                self._markdown.reset().convert(
-                    _(self._text) % {k: escape(str(v)) for k, v in self.vars.items()}
-                )
+                _markdown()
+                .reset()
+                .convert(_(self._text) % {k: escape(str(v)) for k, v in self.vars.items()})
             )
         except TypeError as err:
             raise TypeError(

--- a/redbot/resource/fetch.py
+++ b/redbot/resource/fetch.py
@@ -261,10 +261,10 @@ class RedFetcher(thor.events.EventEmitter):
         "Handle an error encountered while fetching the response."
         self.emit(
             "debug",
-            f"fetch error {self.request.uri} ({self.check_name}) - {error.desc}",
+            f"fetch error {self.request.uri} ({self.check_name}) - {error.desc}"
+            f"{f' ({error.detail})' if error.detail else ''}",
         )
-        assert error.detail is not None, "detail not set in _response_error"
-        err_sample = error.detail[:40] or ""
+        err_sample = (error.detail or "")[:40]
         if isinstance(error, httperr.ExtraDataError):
             if self.response.status_code == 304:
                 self.response.notes.add("body", BODY_NOT_ALLOWED, sample=err_sample)
@@ -272,8 +272,7 @@ class RedFetcher(thor.events.EventEmitter):
                 self.response.notes.add("body", EXTRA_DATA, sample=err_sample)
         elif isinstance(error, httperr.ChunkError):
             self.response.notes.add("field-transfer-encoding", BAD_CHUNK, chunk_sample=err_sample)
-        elif isinstance(error, httperr.HeaderSpaceError):
-            assert error.detail, "error.detail not set in _response_error"
+        elif isinstance(error, httperr.HeaderSpaceError) and error.detail:
             subject = f"field-{error.detail.lower().strip()}"
             self.response.notes.add(subject, HEADER_NAME_SPACE, header_name=error.detail)
             return


### PR DESCRIPTION
- httplint >= 2026.05.01: Note.summary is now plain str (was Markup), and the per-instance _markdown attr is gone. Update RedbotNote to return str from _get_summary and use a local per-thread Markdown.
- thor >= 0.14.0: new HTTP parse errors (HeaderNoColon/Name/Value, FieldSectionTooLarge, TooManyFields, HeaderLineEnding, ObsoleteFold, ChunkTerminator, OutputSyntax/State). Some are raised without a detail, which tripped an assert in _response_error; surface them via fetch_error with desc + detail in both HTML and text output.