### PR TITLE
Fixed: escape title/css_class/link_uri in generated form and link HTML

### DIFF
--- a/redbot/webui/handlers/run_test.py
+++ b/redbot/webui/handlers/run_test.py
@@ -278,9 +278,9 @@ class RunTestHandler(RequestHandler):
             HTML form string
         """
         base_uri = cls.get_base_uri(ui)
-        title = kwargs.get("title", "")
+        title = escape(kwargs.get("title", ""))
         uri = kwargs.get("uri", "")
-        css_class = kwargs.get("css_class", "")
+        css_class = escape(kwargs.get("css_class", ""))
 
         # Build query string for the action URL
         query_params = []

--- a/redbot/webui/links.py
+++ b/redbot/webui/links.py
@@ -2,6 +2,8 @@
 from typing import Any, List, Optional
 from urllib.parse import urljoin
 
+from markupsafe import escape
+
 from redbot.type import RedWebUiProtocol
 from redbot.webui.handlers import (
     ClientErrorHandler,
@@ -162,7 +164,11 @@ class WebUiLinkGenerator:
                 output_format=res_format or "",
                 descend=descend,
             )
-            return f"<a href='{link_uri}'" f"class='{css_class}' title='{title}'>{link_value}</a>"
+            return (
+                f"<a href='{escape(link_uri)}' "
+                f"class='{escape(css_class)}' title='{escape(title)}'>"
+                f"{escape(link_value)}</a>"
+            )
 
         # For new tests, gather context and delegate to RunTestHandler
         test_uri = urljoin(uri, link or "")


### PR DESCRIPTION
The submit button in test forms and the anchor tag in saved-test links interpolated title, css_class, and link_uri without HTML escaping. The multi-resource template passes resource.request.uri as the button's title; a sub-resource URL containing an apostrophe could break out of the attribute and inject an event handler, which CSP nonce rules do not constrain.

Also fix the missing whitespace between href=... and class=... in the saved-test anchor.