### PR TITLE
Fixed: cap incoming request body size in standalone server

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -42,6 +42,10 @@ host = localhost
 # Port to listen on.
 port = 8000
 
+# Maximum size (bytes) of an incoming request body. Requests that exceed this
+# are rejected with 413. Set to 0 to disable the limit.
+max_request_body_size = 1048576
+
 # The URL where the Web user interface is rooted.
 ui_uri = https://redbot.org/
 

--- a/redbot/daemon.py
+++ b/redbot/daemon.py
@@ -309,6 +309,8 @@ class RedRequestHandler:
         self.uri = b""
         self.req_hdrs: RawHeaderListType = []
         self.req_body = b""
+        self.req_body_overflow = False
+        self.max_req_body = server.config.getint("max_request_body_size", fallback=1048576)
         if not exchange.http_conn.tcp_conn:
             return
         self.client_ip = exchange.http_conn.tcp_conn.socket.getpeername()[0]
@@ -322,9 +324,17 @@ class RedRequestHandler:
         self.req_hdrs = req_hdrs
 
     def request_body(self, chunk: bytes) -> None:
+        if self.req_body_overflow:
+            return
+        if self.max_req_body and len(self.req_body) + len(chunk) > self.max_req_body:
+            self.req_body_overflow = True
+            self.req_body = b""
+            return
         self.req_body += chunk
 
     def request_done(self, trailers: RawHeaderListType) -> None:
+        if self.req_body_overflow:
+            return self.payload_too_large()
         try:
             p_uri = urlsplit(self.uri)
         except UnicodeDecodeError:
@@ -407,6 +417,12 @@ in standalone server mode. Details follow.
         headers.append((b"Content-Type", b"text/plain"))
         self.exchange.response_start(b"400", b"Bad Request", headers)
         self.exchange.response_body(why)
+        self.exchange.response_done([])
+
+    def payload_too_large(self) -> None:
+        headers = [(b"Content-Type", b"text/plain"), (b"Connection", b"close")]
+        self.exchange.response_start(b"413", b"Content Too Large", headers)
+        self.exchange.response_body(b"Request body too large.")
         self.exchange.response_done([])
 
 

--- a/redbot/daemon.py
+++ b/redbot/daemon.py
@@ -329,12 +329,15 @@ class RedRequestHandler:
         if self.max_req_body and len(self.req_body) + len(chunk) > self.max_req_body:
             self.req_body_overflow = True
             self.req_body = b""
+            self.payload_too_large()
             return
         self.req_body += chunk
 
     def request_done(self, trailers: RawHeaderListType) -> None:
+        # If we already responded with 413 mid-body, do nothing: the body
+        # finally finished arriving, or the connection was closed.
         if self.req_body_overflow:
-            return self.payload_too_large()
+            return None
         try:
             p_uri = urlsplit(self.uri)
         except UnicodeDecodeError:
@@ -420,10 +423,22 @@ in standalone server mode. Details follow.
         self.exchange.response_done([])
 
     def payload_too_large(self) -> None:
-        headers = [(b"Content-Type", b"text/plain"), (b"Connection", b"close")]
-        self.exchange.response_start(b"413", b"Content Too Large", headers)
-        self.exchange.response_body(b"Request body too large.")
-        self.exchange.response_done([])
+        # Send 413 immediately and force-close the TCP connection so we stop
+        # reading the rest of the oversized body. Thor strips the Connection
+        # header (it's hop-by-hop) and has no public API on the exchange to
+        # abort, so we reach into http_conn.close_conn() directly.
+        try:
+            self.exchange.response_start(
+                b"413",
+                b"Content Too Large",
+                [(b"Content-Type", b"text/plain")],
+            )
+            self.exchange.response_body(b"Request body too large.")
+            self.exchange.response_done([])
+        finally:
+            http_conn = getattr(self.exchange, "http_conn", None)
+            if http_conn is not None:
+                http_conn.close_conn()
 
 
 # debugging output


### PR DESCRIPTION
The standalone daemon previously accumulated request bodies into memory without bound (req_body += chunk), allowing a single client to drive the process to OOM by streaming a large POST. Add a configurable max_request_body_size (default 1 MiB) and respond 413 once exceeded.