### PR TITLE
Fixed: suppress output after response_done to avoid OutputStateError

### DIFF
--- a/redbot/type.py
+++ b/redbot/type.py
@@ -34,6 +34,7 @@ class RedWebUiProtocol(Protocol):
     nonce: str
     locale: str
     timeout: Optional["thor.loop.ScheduledEvent"]
+    response_done: bool
     link_generator: "LinkGenerator"
 
     def output(self, chunk: str) -> None: ...

--- a/redbot/webui/__init__.py
+++ b/redbot/webui/__init__.py
@@ -112,6 +112,7 @@ class RedWebUi:
 
         self.save_path: str
         self.timeout: Optional[thor.loop.ScheduledEvent] = None
+        self.response_done: bool = False
 
         self.nonce: str = standard_b64encode(getrandbits(128).to_bytes(16, "big")).decode("ascii")
         self.start = time.time()
@@ -161,10 +162,13 @@ class RedWebUi:
             formatter.start_output()
             formatter.error_output(message)
         self.exchange.response_done([])
+        self.response_done = True
         if log_message:
             self.error_log(log_message)
 
     def output(self, chunk: str) -> None:
+        if self.response_done:
+            return
         self.exchange.response_body(chunk.encode(self.charset, "replace"))
 
     def error_log(self, message: str) -> None:
@@ -181,6 +185,7 @@ class RedWebUi:
         formatter.resource.stop()
         formatter.error_output("REDbot timeout.")
         self.exchange.response_done([])
+        self.response_done = True
 
     def get_client_id(self) -> str:
         """

--- a/redbot/webui/handlers/run_test.py
+++ b/redbot/webui/handlers/run_test.py
@@ -163,6 +163,7 @@ class RunTestHandler(RequestHandler):
                 ui.timeout.delete()
                 ui.timeout = None
             ui.exchange.response_done([])
+            ui.response_done = True
             save_test(ui, top_resource)
 
             # log excessive traffic


### PR DESCRIPTION
When max_runtime fires, timeout_error calls response_done, but a previously scheduled formatter _done callback can still run and try to write more body, crashing with OutputStateError. Track a response_done flag on the WebUI and make output() a no-op once set.