### PR TITLE
Fixed: guard formatter_done against double response_done

### DIFF
--- a/redbot/resource/__init__.py
+++ b/redbot/resource/__init__.py
@@ -133,11 +133,7 @@ class HttpResource(RedFetcher):
             if not self.response.base_uri:
                 self.response.base_uri = base
             return
-        if (
-            self.descend
-            and tag not in ["a"]
-            and link not in self.links[tag]
-        ):
+        if self.descend and tag not in ["a"] and link not in self.links[tag]:
             linked = HttpResource(self.config)
             linked.set_request(urljoin(base, link), headers=self.request.headers.text)
             self.linked.append((linked, tag))

--- a/redbot/webui/handlers/run_test.py
+++ b/redbot/webui/handlers/run_test.py
@@ -162,8 +162,9 @@ class RunTestHandler(RequestHandler):
             if ui.timeout:
                 ui.timeout.delete()
                 ui.timeout = None
-            ui.exchange.response_done([])
-            ui.response_done = True
+            if not ui.response_done:
+                ui.exchange.response_done([])
+                ui.response_done = True
             save_test(ui, top_resource)
 
             # log excessive traffic


### PR DESCRIPTION
When the request timer fires before the formatter finishes, timeout_error already calls exchange.response_done() and sets ui.response_done. The formatter then still emits formatter_done, which previously called response_done() a second time and raised OutputStateError from thor. Guard the call with ui.response_done so the second invocation is a no-op.

Also reformat redbot/resource/__init__.py via make tidy.