### PR TITLE
Fixed: make WebUi response lifecycle idempotent

### DIFF
--- a/redbot/type.py
+++ b/redbot/type.py
@@ -34,6 +34,7 @@ class RedWebUiProtocol(Protocol):
     nonce: str
     locale: str
     timeout: Optional["thor.loop.ScheduledEvent"]
+    response_started: bool
     response_done: bool
     link_generator: "LinkGenerator"
 

--- a/redbot/webui/__init__.py
+++ b/redbot/webui/__init__.py
@@ -112,6 +112,7 @@ class RedWebUi:
 
         self.save_path: str
         self.timeout: Optional[thor.loop.ScheduledEvent] = None
+        self.response_started: bool = False
         self.response_done: bool = False
 
         self.nonce: str = standard_b64encode(getrandbits(128).to_bytes(16, "big")).decode("ascii")
@@ -133,6 +134,10 @@ class RedWebUi:
         log_message: Optional[str] = None,
     ) -> None:
         """Send an error response."""
+        if self.response_done:
+            if log_message:
+                self.error_log(log_message)
+            return
         # Create formatter for error display
         formatter = find_formatter("html")(
             self.config,
@@ -158,6 +163,7 @@ class RedWebUi:
                 (b"Vary", b"Accept-Language"),
             ],
         )
+        self.response_started = True
         with set_locale(self.locale):
             formatter.start_output()
             formatter.error_output(message)
@@ -178,11 +184,18 @@ class RedWebUi:
         self, formatter: Formatter, detail: Optional[Callable[[], str]] = None
     ) -> None:
         """Max runtime reached."""
+        if self.response_done:
+            return
         details = ""
         if detail:
             details = f"detail={detail()}"
         self.error_log(f"timeout <{formatter.resource.request.uri}> {details}")
         formatter.resource.stop()
+        if not self.response_started:
+            # Response hasn't started yet (e.g. timeout during captcha verify);
+            # send a proper error response instead of a half-formed one.
+            self.error_response(b"504", b"Gateway Timeout", "REDbot timeout.")
+            return
         formatter.error_output("REDbot timeout.")
         self.exchange.response_done([])
         self.response_done = True

--- a/redbot/webui/handlers/run_test.py
+++ b/redbot/webui/handlers/run_test.py
@@ -205,6 +205,7 @@ class RunTestHandler(RequestHandler):
             ]
             + extra_headers,
         )
+        ui.response_started = True
         if "check_name" in ui.query_string:
             check_name = ui.query_string.get("check_name", [""])[0]
             display_resource = cast(


### PR DESCRIPTION
Guards against three race conditions in the response lifecycle:

- error_response now no-ops if the response is already done, so a late async error (e.g. captcha failure after timeout) is logged but doesn't double-send.
- timeout_error no-ops if response is already done.
- timeout_error now handles firing before response_start (e.g. when captcha verification takes longer than max_runtime) by sending a proper 504 via error_response instead of calling response_done on an unstarted exchange and raising OutputStateError.

Adds a response_started flag on RedWebUi to track exchange state.