### PR TITLE
Claude/determined buck 6c7037

### DIFF
--- a/redbot/webui/captcha.py
+++ b/redbot/webui/captcha.py
@@ -102,9 +102,14 @@ class CaptchaHandler:
         exchange = token_client.exchange()
         captcha_status: bytes = b""
         captcha_body: bytes = b""
+        decided = False
 
         @thor.events.on(exchange)
         def error(err_msg: HttpError) -> None:
+            nonlocal decided
+            if decided:
+                return
+            decided = True
             self.error_response(
                 b"403",
                 b"Forbidden",
@@ -124,6 +129,10 @@ class CaptchaHandler:
 
         @thor.events.on(exchange)
         def response_done(_: RawHeaderListType) -> None:
+            nonlocal decided
+            if decided:
+                return
+            decided = True
             try:
                 results = json.loads(captcha_body)
             except ValueError:

--- a/redbot/webui/handlers/run_test.py
+++ b/redbot/webui/handlers/run_test.py
@@ -154,6 +154,12 @@ class RunTestHandler(RequestHandler):
     ) -> None:
         """Preliminary checks are done; actually run the test."""
 
+        # The response may already have been finalized while we were waiting
+        # for captcha verification (e.g. the runtime timeout fired and sent a
+        # 504). Starting a new response now would raise OutputStateError.
+        if ui.response_done:
+            return
+
         if not extra_headers:
             extra_headers = []
 

--- a/redbot/webui/handlers/save.py
+++ b/redbot/webui/handlers/save.py
@@ -211,7 +211,10 @@ class LoadSavedTestHandler(RequestHandler):
 
         @thor.events.on(formatter)
         def formatter_done() -> None:
+            if ui.response_done:
+                return
             ui.exchange.response_done([])
+            ui.response_done = True
 
         formatter.bind_resource(display_resource)
 


### PR DESCRIPTION
Three follow-ups to the WebUI response-lifecycle fixes in #406–#408. Each addresses a distinct race that can still trigger `OutputStateError` on the thor exchange.

- **`47f7b175` — guard `_continue_test` against late captcha resolution.** If the runtime timeout (`ui.timeout`, armed before captcha verification) fires while the captcha exchange is in flight, `timeout_error` sends a 504 and sets `response_done`. When the captcha server eventually responds successfully, `continue_test` calls `_continue_test`, which would issue a second `response_start`. Bail early if `ui.response_done` is set.

- **`fc0a0ea5` — latch captcha verify callbacks.** `verify_captcha` registers both `error` and `response_done` on the same thor exchange. Thor can deliver both (e.g. socket reset after a partial body), which then calls `error_response` and `continue_test` in sequence on the same `RedWebUi`. A `nonlocal decided` latch ensures only the first callback acts.

- **`b9581d3b` — make `LoadSavedTestHandler.formatter_done` idempotent.** Same shape as the bug fixed for `RunTestHandler` in #407: the handler called `exchange.response_done([])` unconditionally, so a duplicate `formatter_done` emission raises `OutputStateError`. Mirror the `RunTestHandler` guard (`if ui.response_done: return` + set the flag).