### PR TITLE
Claude/hopeful shaw 439ed0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "markdown >= 3.4.4",
     "MarkupSafe >= 2.1.3",
     "netaddr >= 1.2.1",
-    "thor >= 0.14.0",
+    "thor >= 0.15.0",
     "typing-extensions >= 4.8.0",
 ]
 

--- a/redbot/cli.py
+++ b/redbot/cli.py
@@ -10,7 +10,6 @@ from configparser import ConfigParser
 
 import thor
 
-from redbot import __version__
 from redbot.formatter import available_formatters, find_formatter
 from redbot.resource import HttpResource
 

--- a/redbot/daemon.py
+++ b/redbot/daemon.py
@@ -423,22 +423,15 @@ in standalone server mode. Details follow.
         self.exchange.response_done([])
 
     def payload_too_large(self) -> None:
-        # Send 413 immediately and force-close the TCP connection so we stop
-        # reading the rest of the oversized body. Thor strips the Connection
-        # header (it's hop-by-hop) and has no public API on the exchange to
-        # abort, so we reach into http_conn.close_conn() directly.
-        try:
-            self.exchange.response_start(
-                b"413",
-                b"Content Too Large",
-                [(b"Content-Type", b"text/plain")],
-            )
-            self.exchange.response_body(b"Request body too large.")
-            self.exchange.response_done([])
-        finally:
-            http_conn = getattr(self.exchange, "http_conn", None)
-            if http_conn is not None:
-                http_conn.close_conn()
+        # Send 413 and close the TCP connection so we stop reading the rest
+        # of the oversized body.
+        self.exchange.response_start(
+            b"413",
+            b"Content Too Large",
+            [(b"Content-Type", b"text/plain")],
+        )
+        self.exchange.response_body(b"Request body too large.")
+        self.exchange.response_done([], close=True)
 
 
 # debugging output

--- a/redbot/formatter/__init__.py
+++ b/redbot/formatter/__init__.py
@@ -3,11 +3,8 @@ Formatters for REDbot output.
 """
 
 import inspect
-import locale
 import sys
 import time
-import unittest
-from collections import defaultdict
 from configparser import SectionProxy
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
 

--- a/redbot/formatter/html.py
+++ b/redbot/formatter/html.py
@@ -13,7 +13,6 @@ from httplint import get_field_description
 from httplint.note import Note, categories, levels
 from typing_extensions import Unpack
 
-from redbot import __version__
 from redbot.formatter import FormatterArgs
 from redbot.formatter.html_base import (
     NL,

--- a/redbot/formatter/html_base.py
+++ b/redbot/formatter/html_base.py
@@ -1,7 +1,6 @@
 import json
 import os
 import time
-from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlparse
 
 import httplint
@@ -39,9 +38,6 @@ __all__ = [
     "Markup",
     "escape",
 ]
-
-if TYPE_CHECKING:
-    from redbot.webui.handlers.base import RequestHandler
 
 NL = "\n"
 

--- a/redbot/resource/__init__.py
+++ b/redbot/resource/__init__.py
@@ -16,7 +16,6 @@ from urllib.parse import urljoin
 
 import thor
 
-from redbot.formatter import f_num
 from redbot.resource import link_parse
 from redbot.resource.active_check import active_checks
 from redbot.resource.fetch import RedFetcher

--- a/redbot/webui/__init__.py
+++ b/redbot/webui/__init__.py
@@ -2,24 +2,19 @@
 A Web UI for RED, the Resource Expert Droid.
 """
 
-import os
-import string
 import sys
 import time
 from base64 import standard_b64encode
-from collections import defaultdict
 from configparser import SectionProxy
-from functools import partial, update_wrapper
 from random import getrandbits
-from typing import Callable, Dict, List, Optional, Tuple, Union, cast
-from urllib.parse import parse_qs, urlencode, urlsplit
+from typing import Callable, Optional
+from urllib.parse import parse_qs
 
 import thor
 import thor.http.common
 from babel.core import negotiate_locale
 from thor.http import get_header
 
-from redbot import __version__
 from redbot.formatter import Formatter, find_formatter
 from redbot.i18n import AVAILABLE_LOCALES, DEFAULT_LOCALE, set_locale
 from redbot.resource import HttpResource
@@ -27,7 +22,6 @@ from redbot.type import (
     HttpResponseExchange,
     LinkGenerator,
     RawHeaderListType,
-    StrHeaderListType,
 )
 from redbot.webui.handlers import (
     ClientErrorHandler,
@@ -39,7 +33,6 @@ from redbot.webui.handlers import (
     ShowHandler,
 )
 from redbot.webui.links import WebUiLinkGenerator
-from redbot.webui.saved_tests import init_save_file, save_test
 
 CSP = "script-src"
 

--- a/redbot/webui/handlers/__init__.py
+++ b/redbot/webui/handlers/__init__.py
@@ -4,7 +4,6 @@ Request handlers for REDbot Web UI.
 This package contains all request handlers implementing the RequestHandler pattern.
 """
 
-from redbot.webui.handlers.base import RequestHandler
 from redbot.webui.handlers.client_error import ClientErrorHandler
 from redbot.webui.handlers.error import ErrorHandler
 from redbot.webui.handlers.run_test import RunTestHandler

--- a/redbot/webui/handlers/client_error.py
+++ b/redbot/webui/handlers/client_error.py
@@ -5,13 +5,9 @@ This module provides a handler for logging client-side JavaScript errors.
 """
 
 import string
-from typing import TYPE_CHECKING
 
 from redbot.type import RedWebUiProtocol
 from redbot.webui.handlers.base import RequestHandler
-
-if TYPE_CHECKING:
-    from redbot.webui import RedWebUi
 
 
 class ClientErrorHandler(RequestHandler):

--- a/redbot/webui/handlers/error.py
+++ b/redbot/webui/handlers/error.py
@@ -4,13 +4,8 @@ Error handler for REDbot Web UI.
 This module provides a fallback handler for unsupported methods (405) and unknown requests (404).
 """
 
-from typing import TYPE_CHECKING
-
 from redbot.type import RedWebUiProtocol
 from redbot.webui.handlers.base import RequestHandler
-
-if TYPE_CHECKING:
-    from redbot.webui import RedWebUi
 
 
 class ErrorHandler(RequestHandler):

--- a/redbot/webui/handlers/run_test.py
+++ b/redbot/webui/handlers/run_test.py
@@ -24,7 +24,6 @@ from redbot.webui.saved_tests import init_save_file, save_test
 
 if TYPE_CHECKING:
     from redbot.formatter import Formatter
-    from redbot.webui import RedWebUi
 
 
 class RunTestHandler(RequestHandler):

--- a/redbot/webui/handlers/save.py
+++ b/redbot/webui/handlers/save.py
@@ -9,7 +9,7 @@ import os
 import pickle
 import time
 import zlib
-from typing import IO, TYPE_CHECKING, Any, cast
+from typing import IO, Any, cast
 from urllib.parse import urlencode
 
 import thor.events
@@ -18,9 +18,6 @@ from markupsafe import escape
 from redbot.formatter import find_formatter
 from redbot.type import RedWebUiProtocol
 from redbot.webui.handlers.base import RequestHandler
-
-if TYPE_CHECKING:
-    from redbot.webui import RedWebUi
 
 
 class SaveHandler(RequestHandler):

--- a/redbot/webui/handlers/show.py
+++ b/redbot/webui/handlers/show.py
@@ -4,7 +4,7 @@ Show handler for REDbot Web UI.
 This module provides a handler for the main REDbot interface page.
 """
 
-from typing import TYPE_CHECKING, Any, Tuple, cast
+from typing import Any, Tuple, cast
 from urllib.parse import urlencode
 
 from redbot.formatter import html
@@ -12,9 +12,6 @@ from redbot.i18n import set_locale
 from redbot.resource import HttpResource
 from redbot.type import RedWebUiProtocol, StrHeaderListType
 from redbot.webui.handlers.base import RequestHandler
-
-if TYPE_CHECKING:
-    from redbot.webui import RedWebUi
 
 
 class ShowHandler(RequestHandler):


### PR DESCRIPTION
## Summary

- Bump `thor` floor to 0.15.0.
- Use the new `response_done(close=True)` flag in the 413 path instead of reaching into `http_conn.close_conn()`.
- Drop 16 unused imports left over from the webui handler refactor (stale `TYPE_CHECKING` shims for `RedWebUi`, plus `os`/`string`/`defaultdict`/`partial`/various `typing` names in `redbot/webui/__init__.py`, and a few `__version__` / `f_num` / `RequestHandler` imports elsewhere).

## Test plan

- [x] `make typecheck`
- [x] `make lint`
- [x] `make test`