### PR TITLE
Claude/vibrant wozniak 284617

### DIFF
--- a/redbot/resource/__init__.py
+++ b/redbot/resource/__init__.py
@@ -56,7 +56,7 @@ class HttpResource(RedFetcher):
         self.linked: List[Tuple[HttpResource, str]] = []  # linked HttpResources
         self._link_parser = link_parse.HTMLLinkParser(self.response, [self.process_link])
         if self.descend or config.getboolean("content_links", False):
-            self.response_content_processors.append(self._link_parser.feed_bytes)
+            self.response.decoded.processors.append(self._link_parser.feed_bytes)
 
     def run_active_checks(self) -> None:
         """

--- a/redbot/resource/link_parse.py
+++ b/redbot/resource/link_parse.py
@@ -13,6 +13,7 @@ from httplint.message import HttpMessageLinter
 from httplint.syntax import rfc9110
 
 DEFAULT_ENCODING = "utf-8"
+MAX_FEED_BYTES = 2 * 1024 * 1024
 
 
 class HTMLLinkParser(HTMLParser):
@@ -57,6 +58,7 @@ class HTMLLinkParser(HTMLParser):
         self.errors = 0
         self.last_err_pos: int = 0
         self.ok = True
+        self.bytes_fed = 0
         HTMLParser.__init__(self)
 
     def __getstate__(self) -> Dict[str, Any]:
@@ -65,6 +67,10 @@ class HTMLLinkParser(HTMLParser):
     def feed_bytes(self, bchunk: bytes) -> None:
         "Feed a given chunk of bytes to the parser"
         if self.ok:
+            self.bytes_fed += len(bchunk)
+            if self.bytes_fed > MAX_FEED_BYTES:
+                self.ok = False
+                return
             encoding = self.message.character_encoding or DEFAULT_ENCODING
             decoded = bchunk.decode(encoding, "ignore")
             self.feed(decoded)

--- a/test/test_link_parse.py
+++ b/test/test_link_parse.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
+import gzip
 import unittest
+from configparser import ConfigParser
+from redbot.resource import HttpResource
 from redbot.resource.link_parse import HTMLLinkParser
 from httplint.message import HttpMessageLinter
 
@@ -42,6 +45,55 @@ class TestLinkParse(unittest.TestCase):
         self.assertEqual(len(links), len(expected_links))
         for expected in expected_links:
             self.assertIn(expected, links)
+
+    def test_link_parsing_gzip_encoded(self):
+        """Link parser must receive decoded bytes, not the raw network stream."""
+        links = []
+
+        def capture_link(base: str, link: str, tag: str, title: str) -> None:
+            links.append((tag, link))
+
+        message = HttpMessageLinter()
+        message.process_headers([
+            (b"content-type", b"text/html"),
+            (b"content-encoding", b"gzip"),
+        ])
+        message.base_uri = "http://example.com/"
+
+        parser = HTMLLinkParser(message, [capture_link])
+        message.decoded.processors.append(parser.feed_bytes)
+
+        html_content = b'<html><body><a href="/foo">Foo</a></body></html>'
+        compressed = gzip.compress(html_content)
+
+        message.feed_content(compressed)
+        message.finish_content(True)
+
+        self.assertIn(("a", "/foo"), links)
+
+
+    def test_descend_resource_receives_decoded_links(self):
+        """End-to-end: HttpResource with descend=True extracts links from gzip responses."""
+        conf = ConfigParser()
+        conf.add_section("redbot")
+        resource = HttpResource(conf["redbot"], descend=True)
+
+        captured = []
+        resource.process_link = lambda base, link, tag, title: captured.append((tag, link))
+        resource._link_parser.link_procs = [resource.process_link]
+
+        resource.response.process_headers([
+            (b"content-type", b"text/html"),
+            (b"content-encoding", b"gzip"),
+        ])
+        resource.response.base_uri = "http://example.com/"
+
+        body = b'<html><body><a href="/bar">Bar</a></body></html>'
+        resource.response.feed_content(gzip.compress(body))
+        resource.response.finish_content(True)
+
+        self.assertIn(("a", "/bar"), captured)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Cap the HTML link parser at 2 MB of input per response to avoid an event-loop stall (and systemd watchdog kill) caused by Python's `html.parser` going quadratic inside large inline `<script>`/`<style>` bodies — e.g. SPA SSR/hydration blobs.
- Fix a latent bug where the link parser was registered on `response_content_processors` (raw network bytes), so for gzip/brotli responses it received compressed bytes, decoded them as UTF-8 with `errors=ignore`, and silently extracted no links. Moved to `response.decoded.processors` so it sees the decompressed stream.
- Added a regression test that exercises the wiring end-to-end with a gzipped body.

## Test plan
- [x] `make typecheck`
- [x] `make lint`
- [x] `.venv/bin/python -m pytest test/test_link_parse.py` (3 passed, including the new gzip regression test)
- [x] Confirmed the regression test fails when the wiring change is reverted
- [ ] Manual: run a descend against a heavy SPA page (e.g. a TikTok profile) and confirm it completes without tripping the systemd watchdog
- [ ] Manual: run a descend against a gzip-encoded HTML page and confirm linked sub-resources are now fetched