### PR TITLE
Changed: derive the User-Agent URL from ui_uri

### DIFF
--- a/redbot/resource/fetch.py
+++ b/redbot/resource/fetch.py
@@ -23,7 +23,16 @@ from redbot.note import RedbotNote
 from redbot.type import RawHeaderListType, StrHeaderListType
 from redbot.webbotauth import WebBotAuthError, load_signer
 
-UA_STRING = f"RED/{__version__} (https://redbot.org/)".encode("ascii")
+# Fallback UI URL advertised in the User-Agent when ui_uri is not configured
+# (e.g. the CLI). The public instance's ui_uri defaults to the same value.
+DEFAULT_UI_URI = "https://redbot.org/"
+
+
+def ua_string(config: SectionProxy) -> bytes:
+    "The User-Agent for outgoing requests, pointing at this instance's UI URL."
+    uri = config.get("ui_uri", "").strip() or DEFAULT_UI_URI
+    return f"RED/{__version__} ({uri})".encode("ascii", "replace")
+
 
 # Status codes on which a response carrying an Accept-Signature header is treated
 # as a Web Bot Auth challenge to re-send the request signed
@@ -171,7 +180,7 @@ class RedFetcher(thor.events.EventEmitter):
         assert self.request.uri, "uri not set in check"
 
         if "user-agent" not in [i[0].lower() for i in self.request.headers.text]:
-            self.request.headers.process([(b"User-Agent", UA_STRING)])
+            self.request.headers.process([(b"User-Agent", ua_string(self.config))])
         # Requests are sent unsigned; Web Bot Auth signatures are only added when
         # the origin challenges for them (see _response_start).
         self._send_request()

--- a/test/test_ua.py
+++ b/test/test_ua.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+import unittest
+from configparser import ConfigParser
+
+from redbot import __version__
+from redbot.resource.fetch import DEFAULT_UI_URI, ua_string
+
+
+class TestUaString(unittest.TestCase):
+    def _config(self, **values):
+        parser = ConfigParser()
+        parser.read_dict({"redbot": {k: v for k, v in values.items()}})
+        return parser["redbot"]
+
+    def test_defaults_when_ui_uri_unset(self):
+        self.assertEqual(
+            ua_string(self._config()).decode("ascii"),
+            f"RED/{__version__} ({DEFAULT_UI_URI})",
+        )
+
+    def test_uses_ui_uri(self):
+        self.assertEqual(
+            ua_string(self._config(ui_uri="https://red.example/app/")).decode("ascii"),
+            f"RED/{__version__} (https://red.example/app/)",
+        )
+
+    def test_blank_ui_uri_falls_back(self):
+        self.assertEqual(
+            ua_string(self._config(ui_uri="   ")).decode("ascii"),
+            f"RED/{__version__} ({DEFAULT_UI_URI})",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

REDbot's outgoing `User-Agent` hardcoded the public instance's URL:

```
RED/2.4.2 (https://redbot.org/)
```

This builds the URL portion from the configured `ui_uri` instead, so a self-hosted instance advertises its own UI rather than `redbot.org`. When `ui_uri` is unset (e.g. the `redbot` CLI, which doesn't read `config.txt`), it falls back to `https://redbot.org/` — so the default, and the public instance (whose `ui_uri` is already `https://redbot.org/`), are unchanged.

| Config | User-Agent |
|---|---|
| (none / CLI) | `RED/2.4.2 (https://redbot.org/)` |
| `ui_uri = https://red.example/app/` | `RED/2.4.2 (https://red.example/app/)` |

## Changes

- `redbot/resource/fetch.py`: replace the module-level `UA_STRING` constant with `ua_string(config)`, which reads `ui_uri` (fallback `DEFAULT_UI_URI`). `check()` now calls it per request.
- `test/test_ua.py`: covers the default, a custom `ui_uri`, and the blank-falls-back case.

## Testing

`make test`, `make typecheck`, and `make lint` (10.00/10) all pass.

---

🤖 Written by Claude Code (Opus 4.8), driven interactively by @mnot; tests/typecheck/lint run locally and reviewed before pushing.
