### PR TITLE
Added: dynamic Open Graph/Twitter metadata for saved results

### DIFF
--- a/redbot/formatter/html_base.py
+++ b/redbot/formatter/html_base.py
@@ -4,6 +4,7 @@ import time
 from urllib.parse import urljoin, urlparse
 
 import httplint
+from httplint.note import levels
 from jinja2 import Environment, PackageLoader, select_autoescape
 from markupsafe import Markup, escape
 from typing_extensions import Unpack
@@ -106,6 +107,8 @@ class BaseHtmlFormatter(Formatter):
         if self.kw.get("is_blank", None):
             extra_body_class = "blank"
 
+        social_meta = self.social_meta(uri)
+
         tpl = self.templates.get_template("response_start.html")
         self.output(
             tpl.render(
@@ -145,10 +148,44 @@ class BaseHtmlFormatter(Formatter):
                         "extra_body_class": extra_body_class,
                         "descend": self.kw.get("descend", False),
                         "test_id": self.kw.get("test_id", ""),
+                        **social_meta,
                     },
                 )
             )
         )
+
+    def social_meta(self, uri: str) -> dict[str, str]:
+        """
+        Build per-result Open Graph / Twitter card metadata for a saved result.
+
+        Only saved results carry useful metadata: the full resource (and its
+        notes) is available when the <head> is rendered, whereas a live test is
+        still fetching. Returns an empty dict otherwise, so the template falls
+        back to the static site metadata.
+        """
+        if not self.kw.get("is_saved") or not uri:
+            return {}
+        og_url = urljoin(self.template_vars["baseuri"], f"saved/{self.kw.get('test_id', '')}")
+        if getattr(self.resource, "descend", False):
+            description = "REDbot HTTP checks for this resource and its embedded resources."
+        else:
+            notes = getattr(getattr(self.resource, "response", None), "notes", []) or []
+            bad = sum(1 for note in notes if note.level == levels.BAD)
+            warn = sum(1 for note in notes if note.level == levels.WARN)
+            counts = []
+            if bad:
+                counts.append(f"{bad} problem" + ("" if bad == 1 else "s"))
+            if warn:
+                counts.append(f"{warn} warning" + ("" if warn == 1 else "s"))
+            if counts:
+                description = f"{', '.join(counts)} found by REDbot's HTTP checks."
+            else:
+                description = "No problems found by REDbot's HTTP checks."
+        return {
+            "og_title": f"REDbot: {uri}",
+            "og_description": description,
+            "og_url": og_url,
+        }
 
     def finish_output(self) -> None:
         """

--- a/redbot/formatter/templates/response_start.html
+++ b/redbot/formatter/templates/response_start.html
@@ -13,11 +13,20 @@
     <meta name="application-name" content="REDbot" />
     <meta name="ROBOTS" content="INDEX, NOFOLLOW" />
     <meta property="og:type" content="website">
+    <meta property="og:site_name" content="REDbot">
+    <meta property="og:image" content="https://redbot.org/static/logo/redbot-sq.png">
+    {% if og_title %}
+    <meta property="og:title" content="{{ og_title }}">
+    <meta property="og:description" content="{{ og_description }}">
+    <meta property="og:url" content="{{ og_url }}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{{ og_title }}">
+    <meta name="twitter:description" content="{{ og_description }}">
+    {% else %}
     <meta property="og:title" content="REDbot">
     <meta property="og:description" content="REDbot is lint for your HTTP resources.">
     <meta property="og:url" content="https://redbot.org/">
-    <meta property="og:site_name" content="REDbot">
-    <meta property="og:image" content="https://redbot.org/static/logo/redbot-sq.png">
+    {% endif %}
     <link rel="stylesheet" type="text/css" href="{{ static }}/style.css?{{ redbot_version }}">
     <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ static }}/logo/apple-touch-icon-144x144.png" />
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ static }}/logo/apple-touch-icon-152x152.png" />


### PR DESCRIPTION
Saved result pages (`/saved/{id}`) now emit per-result `og:title`, `og:description`, `og:url`, and Twitter summary-card tags, so sharing a saved link unfurls into a meaningful preview (tested URI + a problem/warning roll-up) instead of the generic site card.

## Approach

- Metadata is derived **only for saved results**, where the full resource (and its notes) is already loaded when the `<head>` renders. Live tests are still fetching at that point, so they keep the static site metadata.
- New `social_meta()` helper in `html_base.py` builds the values; the OG block in `response_start.html` is now conditional and adds `twitter:card`/`title`/`description`, with `og:url` pointing at the saved permalink.
- Single results get a `BAD`/`WARN` roll-up (e.g. "1 problem, 2 warnings found by REDbot's HTTP checks."); clean results say "No problems found…"; descend results get a generic "resource and its embedded resources" description (detected via `resource.descend`, since the saved-load path doesn't pass a `descend` kw).
- `og:image` is unchanged (static logo) — no per-result image exists.

## Verification

Ran a local daemon and confirmed all three paths against real checks:
- Live (non-saved) → static OG (unchanged)
- Saved single → dynamic title/description/permalink, correct singular/plural, apostrophe escaped
- Saved descend → generic embedded-resources description

`make typecheck` and `make lint` clean (pylint 10.00/10, j2lint passes).

---

🤖 AI-generated by Claude (Opus 4.8). Design, the link-preview mockup, and the local end-to-end verification were reviewed by @mnot; the human author reviewed before merge.